### PR TITLE
feat: add opt-out support for bevy_eventlistener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_eventlistener"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d65c75b4f81818cacdc8a4302c5413910c5fb7727564deaf95e56e0dea4bd0"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_eventlistener_derive",
+ "bevy_hierarchy",
+ "bevy_utils",
+]
+
+[[package]]
+name = "bevy_eventlistener_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa29be733a02a5d7ca4507ef15f294711c1a0884b9a9a2730640ff4e7d0200ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "bevy_gizmos"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +899,7 @@ version = "0.4.0"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",
+ "bevy_eventlistener",
  "rand",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ resolver = "2"
 
 [dependencies]
 bevy = { version = "0.13.0", default-features = false }
+bevy_eventlistener = { version = "0.7.0", optional = true }
 
 [dev-dependencies]
 bevy-inspector-egui = "0.23"
@@ -30,7 +31,8 @@ default = [
   "span_tween",
   "bevy_asset",
   "bevy_render",
-  "bevy_sprite"
+  "bevy_sprite",
+  "bevy_eventlistener"
 ]
 
 # Tweener implementation by defining a tween in range of time.
@@ -42,6 +44,8 @@ bevy_asset = [ "bevy/bevy_asset" ]
 bevy_render = [ "bevy/bevy_render"]
 # Add some built-in interpolator related to sprite
 bevy_sprite = [ "bevy/bevy_sprite", "bevy_render" ]
+# Add entity-targeted events with bevy_eventlistener
+bevy_eventlistener = [ "dep:bevy_eventlistener" ]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -106,6 +110,14 @@ required-features = [
   "bevy_sprite",
   "bevy_asset",
   "span_tween",
+]
+
+[[example]]
+name = "entity_event"
+path = "examples/demo/entity_event.rs"
+required-features = [
+  "span_tween",
+  "bevy_eventlistener"
 ]
 
 [[example]]

--- a/examples/demo/entity_event.rs
+++ b/examples/demo/entity_event.rs
@@ -1,0 +1,24 @@
+use bevy::prelude::*;
+use bevy_tween::prelude::*;
+use bevy_eventlistener::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((MinimalPlugins, DefaultTweenPlugins))
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn((
+        SpanTweenerBundle::new(Duration::from_secs_f32(0.5))
+            .with_repeat(Repeat::times(5)),
+        On::<SpanTweenerEnded>::run(|listener: Listener<SpanTweenerEnded>| {
+            if listener.is_completed() {
+                println!("done!");
+            } else {
+                println!("repeating");
+            }
+        })
+    ));
+}

--- a/src/span_tween.rs
+++ b/src/span_tween.rs
@@ -116,6 +116,7 @@ use std::{cmp::Ordering, ops, time::Duration};
 
 use crate::utils;
 use bevy::{ecs::system::EntityCommands, prelude::*};
+#[cfg(feature = "bevy_eventlistener")]
 use bevy_eventlistener::prelude::*;
 use tween_timer::{Repeat, RepeatStyle};
 

--- a/src/span_tween.rs
+++ b/src/span_tween.rs
@@ -116,6 +116,7 @@ use std::{cmp::Ordering, ops, time::Duration};
 
 use crate::utils;
 use bevy::{ecs::system::EntityCommands, prelude::*};
+use bevy_eventlistener::prelude::*;
 use tween_timer::{Repeat, RepeatStyle};
 
 use crate::{
@@ -152,6 +153,9 @@ impl Plugin for SpanTweenPlugin {
         .register_type::<TimeBound>()
         .register_type::<TweenTimeSpan>()
         .add_event::<SpanTweenerEnded>();
+
+        #[cfg(feature = "bevy_eventlistener")]
+        app.add_plugins(EventListenerPlugin::<SpanTweenerEnded>::default());
     }
 }
 
@@ -642,9 +646,12 @@ pub fn span_tween(duration: Duration) -> QuickSpanTweenBundle {
 }
 
 /// Fired when a span tweener repeated or completed
+#[cfg_attr(feature = "bevy_eventlistener", derive(EntityEvent))]
+#[cfg_attr(feature = "bevy_eventlistener", can_bubble)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Event, Reflect)]
 pub struct SpanTweenerEnded {
     /// Tween timer that just ended
+    #[cfg_attr(feature = "bevy_eventlistener", target)]
     pub tweener: Entity,
     /// Currently timer direction. If is [`RepeatStyle::PingPong`], the current
     /// direction will be its already changed direction.


### PR DESCRIPTION
This adds support for [`bevy_eventlistener`](https://github.com/aevyrie/bevy_eventlistener), which allows users to attach callbacks to entities and have it react to events targeting that entity.

This doesn't affect users who don't use it and they will still be able to listen to the events normally using `EventReader<SpanTweenerEnded>`. So I made the feature opt-out, but I'm open to making it an opt-in too if there are good reasons to.