### PR TITLE
Update AnimationBuilder and stuffs in `combinators`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Add optional feature for `serde`. ([#31](https://github.com/Multirious/bevy_tween/pull/31))
     - Derive `Serialize` and `Deserialize` for `EaseFunction`
 - Clean up `TweenAppResource` after the app runs. ([#28](https://github.com/Multirious/bevy_tween/pull/28))
+- Update animation builder
+    - Add `.entity_commands()` getter
+    - Add `.time_runner()` getter
+    - Add `.time_runner_mut()` getter
 
 ## v0.5.0 - 2024-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@
 - Add optional feature for `serde`. ([#31](https://github.com/Multirious/bevy_tween/pull/31))
     - Derive `Serialize` and `Deserialize` for `EaseFunction`
 - Clean up `TweenAppResource` after the app runs. ([#28](https://github.com/Multirious/bevy_tween/pull/28))
-- Update animation builder
+- Update animation builder ([#36](https://github.com/Multirious/bevy_tween/pull/36))
     - Add `.entity_commands()` getter
     - Add `.time_runner()` getter
     - Add `.time_runner_mut()` getter
+    - Add `skipped` method
+    - Add `disabled` method
+    - Add `time_scale` method
+    - Add `direction` method
 
 ## v0.5.0 - 2024-06-09
 

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -2,193 +2,14 @@
 
 use std::time::Duration;
 
-use crate::prelude::TweenEventData;
-
 use bevy::{ecs::system::EntityCommands, prelude::*};
-use bevy_time_runner::{Repeat, RepeatStyle, TimeRunner, TimeSpan};
+use bevy_time_runner::{
+    Repeat, RepeatStyle, SkipTimeRunner, TimeDirection, TimeRunner, TimeSpan,
+};
 
-mod state {
-    use tween::ComponentTween;
-
-    use crate::interpolate::*;
-    use crate::tween::{self, TargetComponent, Tween};
-    use bevy::prelude::*;
-
-    /// Generic target and state
-    pub struct TargetState<T, V> {
-        /// The target type
-        pub target: T,
-        /// The target's value or property
-        pub value: V,
-    }
-
-    impl<T, V> TargetState<T, V> {
-        /// Create new [`TargetState`] from target and initial value
-        /// Recommended to use other methods like:
-        /// - [`TargetComponent::state`]
-        /// - [`TargetAsset::state`](crate::tween::TargetAsset::state)
-        /// - [`TargetResource::state`](crate::tween::TargetAsset::state)
-        pub fn new(target: T, value: V) -> Self {
-            TargetState { target, value }
-        }
-
-        /// Change the value
-        pub fn set_value(&mut self, new_value: V) -> &mut Self {
-            self.value = new_value;
-            self
-        }
-
-        /// Change the target
-        pub fn set_target(&mut self, new_target: T) -> &mut Self {
-            self.target = new_target;
-            self
-        }
-    }
-
-    impl<T, V> TargetState<T, V>
-    where
-        T: Clone,
-    {
-        /// Create [`ComponentTween`] of a value from this state and relative interpolator constructor
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// # use bevy::prelude::*;
-        /// # use bevy_tween::prelude::*;
-        /// use bevy_tween::interpolate::translation_to;
-        ///
-        /// # let sprite = Entity::PLACEHOLDER;
-        /// let my_target = sprite.into_target();
-        /// let mut my_target_translation = my_target.state(Vec3::ZERO);
-        ///
-        /// // Creating a ComponentTween that's tweening from previous value to Vec3::ONE
-        /// let tween = my_target_translation.with(translation_to(Vec3::ONE));
-        /// ```
-        pub fn with<I>(&mut self, f: impl FnOnce(&mut V) -> I) -> Tween<T, I> {
-            let interpolator = f(&mut self.value);
-            Tween {
-                target: self.target.clone(),
-                interpolator,
-            }
-        }
-    }
-
-    /// Extension trait to create [`TransformTargetState`]
-    pub trait TransformTargetStateExt {
-        /// Create [`TransformTargetState`] from [`Self`] and initial value
-        fn transform_state(&self, value: Transform) -> TransformTargetState;
-    }
-
-    impl TransformTargetStateExt for TargetComponent {
-        /// Create [`TransformTargetState`] from [`TargetComponent`] and initial value
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// # use bevy_tween::prelude::*;
-        /// # use bevy::prelude::*;
-        /// # let sprite = Entity::PLACEHOLDER;
-        /// let my_target = sprite.into_target();
-        /// let mut my_target_translation = my_target.transform_state(Transform::IDENTITY);
-        ///
-        /// // Creating a ComponentTween that's tweening from previous translation to Vec3::ONE
-        /// let tween = my_target_translation.translation_to(Vec3::ONE);
-        /// ```
-        fn transform_state(&self, value: Transform) -> TransformTargetState {
-            TransformTargetState::new(self.clone(), value)
-        }
-    }
-
-    /// Transform state for animating entity
-    pub struct TransformTargetState {
-        target: TargetComponent,
-        value: Transform,
-    }
-
-    impl TransformTargetState {
-        /// Create new [`TransformTargetState`]
-        pub fn new(
-            target: TargetComponent,
-            value: Transform,
-        ) -> TransformTargetState {
-            TransformTargetState { target, value }
-        }
-
-        /// Create [`ComponentTween`] of transform from this state and relative interpolator constructor
-        pub fn transform_with<I>(
-            &mut self,
-            f: impl FnOnce(&mut Transform) -> I,
-        ) -> Tween<TargetComponent, I> {
-            let interpolator = f(&mut self.value);
-            Tween {
-                target: self.target.clone(),
-                interpolator,
-            }
-        }
-
-        /// Create [`ComponentTween`] of transform's translation from this state and relative interpolator constructor
-        pub fn translation_with<I>(
-            &mut self,
-            f: impl FnOnce(&mut Vec3) -> I,
-        ) -> Tween<TargetComponent, I> {
-            self.transform_with(|v| f(&mut v.translation))
-        }
-
-        /// Create [`ComponentTween`] of transform's rotation from this state and relative interpolator constructor
-        pub fn rotation_with<I>(
-            &mut self,
-            f: impl FnOnce(&mut Quat) -> I,
-        ) -> Tween<TargetComponent, I> {
-            self.transform_with(|v| f(&mut v.rotation))
-        }
-
-        /// Create [`ComponentTween`] of transform's scale from this state and relative interpolator constructor
-        pub fn scale_with<I>(
-            &mut self,
-            f: impl FnOnce(&mut Vec3) -> I,
-        ) -> Tween<TargetComponent, I> {
-            self.transform_with(|v| f(&mut v.scale))
-        }
-
-        /// Create [`ComponentTween`] of transform's translation tweening to provided input
-        pub fn translation_to(
-            &mut self,
-            to: Vec3,
-        ) -> ComponentTween<Translation> {
-            self.translation_with(translation_to(to))
-        }
-
-        /// Create [`ComponentTween`] of transform's rotation tweening to provided input
-        pub fn rotation_to(&mut self, to: Quat) -> ComponentTween<Rotation> {
-            self.rotation_with(rotation_to(to))
-        }
-
-        /// Create [`ComponentTween`] of transform's scale tweening to provided input
-        pub fn scale_to(&mut self, to: Vec3) -> ComponentTween<Scale> {
-            self.scale_with(scale_to(to))
-        }
-
-        /// Create [`ComponentTween`] of transform's translation tweening by provided input
-        pub fn translation_by(
-            &mut self,
-            by: Vec3,
-        ) -> ComponentTween<Translation> {
-            self.translation_with(translation_by(by))
-        }
-
-        /// Create [`ComponentTween`] of transform's rotation tweening by provided input
-        pub fn rotation_by(&mut self, by: Quat) -> ComponentTween<Rotation> {
-            self.rotation_with(rotation_by(by))
-        }
-
-        /// Create [`ComponentTween`] of transform's scale tweening by provided input
-        pub fn scale_by(&mut self, by: Vec3) -> ComponentTween<Scale> {
-            self.scale_with(scale_by(by))
-        }
-    }
-}
-
+mod animation_combinators;
+mod state;
+pub use animation_combinators::*;
 pub use state::{TargetState, TransformTargetState, TransformTargetStateExt};
 
 /// Commands to use within an animation combinator
@@ -225,6 +46,7 @@ impl<'a> AnimationBuilderExt for EntityCommands<'a> {
             entity_commands: self.reborrow(),
             time_runner: None,
             custom_length: None,
+            skipped: false,
         }
     }
 }
@@ -238,6 +60,7 @@ impl<'w, 's> AnimationBuilderExt for Commands<'w, 's> {
             entity_commands,
             time_runner: None,
             custom_length: None,
+            skipped: false,
         }
     }
 }
@@ -251,6 +74,7 @@ impl<'a> AnimationBuilderExt for ChildBuilder<'a> {
             entity_commands,
             time_runner: None,
             custom_length: None,
+            skipped: false,
         }
     }
 }
@@ -260,6 +84,7 @@ pub struct AnimationBuilder<'a> {
     entity_commands: EntityCommands<'a>,
     time_runner: Option<TimeRunner>,
     custom_length: Option<Duration>,
+    skipped: bool,
 }
 impl<'a> AnimationBuilder<'a> {
     /// Get the inner [`EntityCommands`]
@@ -279,8 +104,7 @@ impl<'a> AnimationBuilder<'a> {
 
     /// Configure [`TimeRunner`]'s [`Repeat`]
     pub fn repeat(mut self, repeat: Repeat) -> Self {
-        let time_runner =
-            self.time_runner.get_or_insert_with(TimeRunner::default);
+        let time_runner = self.time_runner_or_default();
         match time_runner.repeat() {
             Some((_, repeat_style)) => {
                 time_runner.set_repeat(Some((repeat, repeat_style)));
@@ -294,8 +118,7 @@ impl<'a> AnimationBuilder<'a> {
 
     /// Configure [`TimeRunner`]'s [`RepeatStyle`]
     pub fn repeat_style(mut self, repeat_style: RepeatStyle) -> Self {
-        let time_runner =
-            self.time_runner.get_or_insert_with(TimeRunner::default);
+        let time_runner = self.time_runner_or_default();
         match time_runner.repeat() {
             Some((repeat, _)) => {
                 time_runner.set_repeat(Some((repeat, repeat_style)));
@@ -308,18 +131,47 @@ impl<'a> AnimationBuilder<'a> {
         self
     }
 
-    /// Configure [`TimeRunner`]'s `paused`
+    /// Configure [`TimeRunner`]'s `paused`. Note that pausing only pauses the timer
+    /// but not the animation it self.
     pub fn paused(mut self, paused: bool) -> Self {
-        self.time_runner
-            .get_or_insert_with(TimeRunner::default)
-            .set_paused(paused);
+        self.time_runner_or_default().set_paused(paused);
         self
     }
 
-    /// Use custom duration instead of determined by combinator duration.
+    /// Skip [`TimeRunner`] from inserting [`TimeSpanProgress`](bevy_time_runner::TimeSpanProgress) which is a signal
+    /// for an animation entity to execute animation code.
+    pub fn skipped(mut self, skipped: bool) -> Self {
+        self.skipped = skipped;
+        self
+    }
+
+    /// [`Self::paused`] and [`Self::skipped`]
+    pub fn disabled(self, disabled: bool) -> Self {
+        self.paused(disabled).skipped(disabled)
+    }
+
+    /// Use custom duration instead of determined by [`insert`](Self::insert).
     pub fn length(mut self, duration: Duration) -> Self {
         self.custom_length = Some(duration);
         self
+    }
+
+    /// Configure [`TimeRunner`]'s time scale to adjust animation speed.
+    /// Negative scale cause animation play in the opposite of [`TimeDirection`] and
+    /// [`Repeat`] counter will tick backward.
+    pub fn time_scale(mut self, scale: f32) -> Self {
+        self.time_runner_or_default().set_time_scale(scale);
+        self
+    }
+
+    /// Configure [`TimeRunner`]'s direction to play animation backward or forward.
+    pub fn direction(mut self, direction: TimeDirection) -> Self {
+        self.time_runner_or_default().set_direction(direction);
+        self
+    }
+
+    fn time_runner_or_default(&mut self) -> &mut TimeRunner {
+        self.time_runner.get_or_insert_with(TimeRunner::default)
     }
 
     /// Add animations from a closure. Animation entities will be subjected
@@ -336,6 +188,7 @@ impl<'a> AnimationBuilder<'a> {
             mut entity_commands,
             time_runner,
             custom_length,
+            skipped,
         } = self;
         let mut dur = Duration::ZERO;
         entity_commands.with_children(|c| {
@@ -352,6 +205,9 @@ impl<'a> AnimationBuilder<'a> {
             }
         }
         entity_commands.insert(time_runner);
+        if skipped {
+            entity_commands.insert(SkipTimeRunner);
+        }
         entity_commands
     }
 
@@ -373,6 +229,7 @@ impl<'a> AnimationBuilder<'a> {
             mut entity_commands,
             time_runner,
             custom_length,
+            skipped,
         } = self;
         let mut time_runner = time_runner.unwrap_or_default();
         match custom_length {
@@ -390,349 +247,9 @@ impl<'a> AnimationBuilder<'a> {
             tweens,
             time_runner,
         ));
+        if skipped {
+            entity_commands.insert(SkipTimeRunner);
+        }
         entity_commands
     }
-}
-
-// fn test_system(mut commands: Commands) {
-//     use crate::{interpolate::translation, prelude::*, tween::TargetComponent};
-
-//     let my_entity = commands.spawn_empty().id();
-//     let target = TargetComponent::Entity(my_entity);
-//     commands
-//         .make_animation()
-//         .repeat(Repeat::Infinitely)
-//         .animate(|a, pos| {
-//             let walk = || {
-//                 tween(
-//                     Duration::from_secs(1),
-//                     EaseFunction::Linear,
-//                     target.with(translation(Vec3::ZERO, Vec3::ONE)),
-//                 )
-//             };
-//             sequence((walk(), walk()))(a, pos)
-//         });
-
-//     let target = TargetComponent::TweenerEntity;
-//     let my_entity = commands
-//         .spawn_empty()
-//         .make_animation()
-//         .repeat(Repeat::Infinitely)
-//         .animate(|a, pos| {
-//             let walk = || {
-//                 tween(
-//                     Duration::from_secs(1),
-//                     EaseFunction::Linear,
-//                     target.with(translation(Vec3::ZERO, Vec3::ONE)),
-//                 )
-//             };
-//             sequence((walk(), walk()))(a, pos)
-//         });
-
-//     let target = TargetComponent::TweenerEntity;
-//     let my_entity = commands.spawn_empty().with_children(|c| {
-//         c.make_animation()
-//             .repeat(Repeat::Infinitely)
-//             .animate(|a, pos| {
-//                 let walk = || {
-//                     tween(
-//                         Duration::from_secs(1),
-//                         EaseFunction::Linear,
-//                         target.with(translation(Vec3::ZERO, Vec3::ONE)),
-//                     )
-//                 };
-//                 sequence((walk(), walk()))(a, pos)
-//             });
-//     });
-// }
-
-/// Animations in sequence.
-///
-/// Each animation output will be passed to the next one.
-/// Returns position from the last animation.
-pub fn sequence<S>(
-    sequence: S,
-) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
-where
-    S: Sequence,
-{
-    move |b, pos| sequence.call(b, pos)
-}
-
-/// Animations in parallel.
-///
-/// Each animation will receive the same starting position.
-/// Returns the longest offset from the passed animations.
-pub fn parallel<P>(
-    parallel: P,
-) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
-where
-    P: Parallel,
-{
-    move |b, pos| parallel.call(b, pos)
-}
-
-/// Combinator for creating a basic tween using interpolation and a tween.
-///
-/// Starts from last position and tween for provided `duration`
-///
-/// Position is shifted to this tween's end.
-pub fn tween<I, T>(
-    duration: Duration,
-    interpolation: I,
-    tween: T,
-) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
-where
-    I: Bundle,
-    T: Bundle,
-{
-    move |a, pos| {
-        let start = *pos;
-        let end = start + duration;
-        a.spawn((
-            TimeSpan::try_from(start..end).unwrap(),
-            interpolation,
-            tween,
-        ));
-        *pos = end;
-    }
-}
-
-/// Combinator for creating a basic tween using interpolation and a tween.
-///
-/// Starts and ends at provided span.
-///
-/// Position is not mutated because the operation is not relative.
-pub fn tween_exact<S, I, T>(
-    span: S,
-    interpolation: I,
-    tween: T,
-) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
-where
-    S: TryInto<TimeSpan>,
-    S::Error: std::fmt::Debug,
-    I: Bundle,
-    T: Bundle,
-{
-    move |a, _pos| {
-        a.spawn((span.try_into().unwrap(), interpolation, tween));
-    }
-}
-
-/// Combinator for creating an tween event.
-///
-/// Event will be emitted at the last position.
-///
-/// Position is not mutated because the event has no length.
-pub fn event<Data>(
-    event_data: Data,
-) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
-where
-    Data: Send + Sync + 'static,
-{
-    move |a, pos| {
-        a.spawn((
-            TimeSpan::try_from(*pos..=*pos).unwrap(),
-            TweenEventData::with_data(event_data),
-        ));
-    }
-}
-
-/// Combinator for creating an tween event.
-///
-/// Event will be emitted at the provided position.
-///
-/// Position is not mutated because the operation is not relative.
-pub fn event_at<Data>(
-    at: Duration,
-    event_data: Data,
-) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
-where
-    Data: Send + Sync + 'static,
-{
-    move |a, _pos| {
-        a.spawn((
-            TimeSpan::try_from(at..=at).unwrap(),
-            TweenEventData::with_data(event_data),
-        ));
-    }
-}
-
-/// Combinator for creating an tween event.
-///
-/// Event will be emitted at the last position for provided length.
-///
-/// Position is not mutated because the operation is not relative.
-pub fn event_for<Data>(
-    length: Duration,
-    event_data: Data,
-) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
-where
-    Data: Send + Sync + 'static,
-{
-    move |a, pos| {
-        let start = *pos;
-        let end = start + length;
-        a.spawn((
-            TimeSpan::try_from(start..end).unwrap(),
-            TweenEventData::with_data(event_data),
-        ));
-        *pos = end;
-    }
-}
-
-/// Combinator for creating an tween event.
-///
-/// Event will be emitted every frame at the provided span.
-///
-/// Position is not mutated because the operation is not relative.
-pub fn event_exact<S, Data>(
-    span: S,
-    event_data: Data,
-) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
-where
-    S: TryInto<TimeSpan>,
-    S::Error: std::fmt::Debug,
-    Data: Send + Sync + 'static,
-{
-    move |a, _pos| {
-        a.spawn((
-            span.try_into().unwrap(),
-            TweenEventData::with_data(event_data),
-        ));
-    }
-}
-
-/// Shift the position forward by provided duration
-pub fn forward(
-    by: Duration,
-) -> impl FnOnce(&mut AnimationCommands, &mut Duration) {
-    move |_, pos| *pos += by
-}
-
-/// Shift the position backward by provided duration
-pub fn backward(
-    by: Duration,
-) -> impl FnOnce(&mut AnimationCommands, &mut Duration) {
-    move |_, pos| *pos = pos.saturating_sub(by)
-}
-
-/// Set the position to the provided duration
-pub fn go(to: Duration) -> impl FnOnce(&mut AnimationCommands, &mut Duration) {
-    move |_, pos| *pos = to
-}
-
-/// Tuple of FnOnces in [`sequence()`],
-/// support up to 16 indexes but can be circumvented by nesting tuples.
-///
-/// This trait is sealed and not meant to be implemented outside of the current crate.
-#[allow(private_bounds)]
-pub trait Sequence: sealed::SequenceSealed {}
-impl<T> Sequence for T where T: sealed::SequenceSealed {}
-
-/// Tuple of FnOnces in [`parallel()`],
-/// support up to 16 indexes but can be circumvented by nesting tuples.
-///
-/// This trait is sealed and not meant to be implemented outside of the current crate.
-#[allow(private_bounds)]
-pub trait Parallel: sealed::ParallelSealed {}
-impl<T> Parallel for T where T: sealed::ParallelSealed {}
-
-mod sealed {
-    use super::*;
-
-    pub(super) trait SequenceSealed {
-        fn call(self, a: &mut AnimationCommands, pos: &mut Duration);
-    }
-
-    impl<T: FnOnce(&mut AnimationCommands, &mut Duration)> SequenceSealed for T {
-        fn call(self, a: &mut AnimationCommands, pos: &mut Duration) {
-            self(a, pos)
-        }
-    }
-
-    pub(super) trait ParallelSealed {
-        fn call(self, a: &mut AnimationCommands, pos: &mut Duration);
-    }
-
-    impl<T: FnOnce(&mut AnimationCommands, &mut Duration)> ParallelSealed for T {
-        fn call(self, a: &mut AnimationCommands, pos: &mut Duration) {
-            self(a, pos)
-        }
-    }
-
-    macro_rules! impl_sequence {
-        ($($i:tt $t:ident)+) => {
-            impl< $($t: SequenceSealed,)+ > SequenceSealed for ($($t,)*) {
-                fn call(self, a: &mut AnimationCommands, pos: &mut Duration) {
-                    $(
-                        self.$i.call(a, pos);
-                    )*
-                }
-            }
-        }
-    }
-    macro_rules! impl_parallel {
-        ($($i:tt $t:ident)+) => {
-            impl< $($t: ParallelSealed,)+ > ParallelSealed for ($($t,)*) {
-                fn call(self, a: &mut AnimationCommands, main_pos: &mut Duration) {
-                    let mut furthest = *main_pos;
-                    let mut pos = *main_pos;
-                    $(
-                        self.$i.call(a, &mut pos);
-                        if pos > furthest {
-                            furthest = pos;
-                        }
-                        #[allow(unused)]
-                        {pos = *main_pos;}
-                    )*
-                    *main_pos = furthest;
-                }
-            }
-        }
-    }
-
-    // It's possible to make a macro that use shorter input but i'm tryna make it simple here
-    //
-    // Built by using Helix macro:
-    //
-    // xyp<S-F>=;b;vf<S-T>eyp<A-;>i<space>jk;f=;b_<C-a>f<S-T>ev<A-;>l<C-a>
-    //
-    // starting from
-    //
-    // impl_TupleFnOnce! { 0 => T0 }
-
-    impl_sequence! { 0 T0 }
-    impl_sequence! { 0 T0 1 T1 }
-    impl_sequence! { 0 T0 1 T1 2 T2 }
-    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 }
-    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 }
-    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 }
-    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 }
-    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 }
-    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 }
-    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 }
-    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 }
-    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 }
-    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 }
-    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 }
-    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 }
-    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 15 T15 }
-
-    impl_parallel! { 0 T0 }
-    impl_parallel! { 0 T0 1 T1 }
-    impl_parallel! { 0 T0 1 T1 2 T2 }
-    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 }
-    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 }
-    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 }
-    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 }
-    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 }
-    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 }
-    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 }
-    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 }
-    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 }
-    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 }
-    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 }
-    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 }
-    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 15 T15 }
 }

--- a/src/combinator/animation_combinators.rs
+++ b/src/combinator/animation_combinators.rs
@@ -1,0 +1,324 @@
+use super::AnimationCommands;
+use crate::prelude::TweenEventData;
+use bevy::prelude::*;
+use bevy_time_runner::TimeSpan;
+use std::time::Duration;
+
+/// Animations in sequence.
+///
+/// Each animation output will be passed to the next one.
+/// Returns position from the last animation.
+pub fn sequence<S>(
+    sequence: S,
+) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
+where
+    S: Sequence,
+{
+    move |b, pos| sequence.call(b, pos)
+}
+
+/// Animations in parallel.
+///
+/// Each animation will receive the same starting position.
+/// Returns the longest offset from the passed animations.
+pub fn parallel<P>(
+    parallel: P,
+) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
+where
+    P: Parallel,
+{
+    move |b, pos| parallel.call(b, pos)
+}
+
+/// Combinator for creating a basic tween using interpolation and a tween.
+///
+/// Starts from last position and tween for provided `duration`
+///
+/// Position is shifted to this tween's end.
+pub fn tween<I, T>(
+    duration: Duration,
+    interpolation: I,
+    tween: T,
+) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
+where
+    I: Bundle,
+    T: Bundle,
+{
+    move |a, pos| {
+        let start = *pos;
+        let end = start + duration;
+        a.spawn((
+            TimeSpan::try_from(start..end).unwrap(),
+            interpolation,
+            tween,
+        ));
+        *pos = end;
+    }
+}
+
+/// Combinator for creating a basic tween using interpolation and a tween.
+///
+/// Starts and ends at provided span.
+///
+/// Position is not mutated because the operation is not relative.
+pub fn tween_exact<S, I, T>(
+    span: S,
+    interpolation: I,
+    tween: T,
+) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
+where
+    S: TryInto<TimeSpan>,
+    S::Error: std::fmt::Debug,
+    I: Bundle,
+    T: Bundle,
+{
+    move |a, _pos| {
+        a.spawn((span.try_into().unwrap(), interpolation, tween));
+    }
+}
+
+/// Combinator for creating an tween event.
+///
+/// Event will be emitted at current position.
+///
+/// Position is not mutated because the event has no length.
+///
+/// <div class="warning">
+///
+/// Your event should be registered with [`TweenEventPlugin`](crate::tween_event::TweenEventPlugin)
+/// or [`TweenEventTakingPlugin`](crate::tween_event::TweenEventTakingPlugin).
+///
+/// </div>
+pub fn event<Data>(
+    event_data: Data,
+) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
+where
+    Data: Send + Sync + 'static,
+{
+    move |a, pos| {
+        a.spawn((
+            TimeSpan::try_from(*pos..=*pos).unwrap(),
+            TweenEventData::with_data(event_data),
+        ));
+    }
+}
+
+/// Combinator for creating an tween event.
+///
+/// Event will be emitted at the provided position.
+///
+/// Position is not mutated because the operation is not relative.
+///
+/// <div class="warning">
+///
+/// Your event should be registered with [`TweenEventPlugin`](crate::tween_event::TweenEventPlugin)
+/// or [`TweenEventTakingPlugin`](crate::tween_event::TweenEventTakingPlugin).
+///
+/// </div>
+pub fn event_at<Data>(
+    at: Duration,
+    event_data: Data,
+) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
+where
+    Data: Send + Sync + 'static,
+{
+    move |a, _pos| {
+        a.spawn((
+            TimeSpan::try_from(at..=at).unwrap(),
+            TweenEventData::with_data(event_data),
+        ));
+    }
+}
+
+/// Combinator for creating an tween event.
+///
+/// Event will be emitted at the current position for provided length every frame.
+///
+/// Position is at the end of the event.
+///
+/// <div class="warning">
+///
+/// Your event should be registered with [`TweenEventPlugin`](crate::tween_event::TweenEventPlugin)
+/// or [`TweenEventTakingPlugin`](crate::tween_event::TweenEventTakingPlugin).
+///
+/// </div>
+pub fn event_for<Data>(
+    length: Duration,
+    event_data: Data,
+) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
+where
+    Data: Send + Sync + 'static,
+{
+    move |a, pos| {
+        let start = *pos;
+        let end = start + length;
+        a.spawn((
+            TimeSpan::try_from(start..end).unwrap(),
+            TweenEventData::with_data(event_data),
+        ));
+        *pos = end;
+    }
+}
+
+/// Combinator for creating an tween event.
+///
+/// Event will be emitted at the provided span every frame.
+///
+/// Position is not mutated because the operation is not relative.
+///
+/// <div class="warning">
+///
+/// Your event should be registered with [`TweenEventPlugin`](crate::tween_event::TweenEventPlugin)
+/// or [`TweenEventTakingPlugin`](crate::tween_event::TweenEventTakingPlugin).
+///
+/// </div>
+pub fn event_exact<S, Data>(
+    span: S,
+    event_data: Data,
+) -> impl FnOnce(&mut AnimationCommands, &mut Duration)
+where
+    S: TryInto<TimeSpan>,
+    S::Error: std::fmt::Debug,
+    Data: Send + Sync + 'static,
+{
+    move |a, _pos| {
+        a.spawn((
+            span.try_into().unwrap(),
+            TweenEventData::with_data(event_data),
+        ));
+    }
+}
+
+/// Shift the position forward by provided duration
+pub fn forward(
+    by: Duration,
+) -> impl FnOnce(&mut AnimationCommands, &mut Duration) {
+    move |_, pos| *pos += by
+}
+
+/// Shift the position backward by provided duration
+pub fn backward(
+    by: Duration,
+) -> impl FnOnce(&mut AnimationCommands, &mut Duration) {
+    move |_, pos| *pos = pos.saturating_sub(by)
+}
+
+/// Set the position to the provided duration
+pub fn go(to: Duration) -> impl FnOnce(&mut AnimationCommands, &mut Duration) {
+    move |_, pos| *pos = to
+}
+
+/// Tuple of FnOnces in [`sequence()`],
+/// support up to 16 indexes but can be circumvented by nesting tuples.
+///
+/// This trait is sealed and not meant to be implemented outside of the current crate.
+#[allow(private_bounds)]
+pub trait Sequence: sealed::SequenceSealed {}
+impl<T> Sequence for T where T: sealed::SequenceSealed {}
+
+/// Tuple of FnOnces in [`parallel()`],
+/// support up to 16 indexes but can be circumvented by nesting tuples.
+///
+/// This trait is sealed and not meant to be implemented outside of the current crate.
+#[allow(private_bounds)]
+pub trait Parallel: sealed::ParallelSealed {}
+impl<T> Parallel for T where T: sealed::ParallelSealed {}
+
+mod sealed {
+    use super::*;
+
+    pub(super) trait SequenceSealed {
+        fn call(self, a: &mut AnimationCommands, pos: &mut Duration);
+    }
+
+    impl<T: FnOnce(&mut AnimationCommands, &mut Duration)> SequenceSealed for T {
+        fn call(self, a: &mut AnimationCommands, pos: &mut Duration) {
+            self(a, pos)
+        }
+    }
+
+    pub(super) trait ParallelSealed {
+        fn call(self, a: &mut AnimationCommands, pos: &mut Duration);
+    }
+
+    impl<T: FnOnce(&mut AnimationCommands, &mut Duration)> ParallelSealed for T {
+        fn call(self, a: &mut AnimationCommands, pos: &mut Duration) {
+            self(a, pos)
+        }
+    }
+
+    macro_rules! impl_sequence {
+        ($($i:tt $t:ident)+) => {
+            impl< $($t: SequenceSealed,)+ > SequenceSealed for ($($t,)*) {
+                fn call(self, a: &mut AnimationCommands, pos: &mut Duration) {
+                    $(
+                        self.$i.call(a, pos);
+                    )*
+                }
+            }
+        }
+    }
+    macro_rules! impl_parallel {
+        ($($i:tt $t:ident)+) => {
+            impl< $($t: ParallelSealed,)+ > ParallelSealed for ($($t,)*) {
+                fn call(self, a: &mut AnimationCommands, main_pos: &mut Duration) {
+                    let mut furthest = *main_pos;
+                    let mut pos = *main_pos;
+                    $(
+                        self.$i.call(a, &mut pos);
+                        if pos > furthest {
+                            furthest = pos;
+                        }
+                        #[allow(unused)]
+                        {pos = *main_pos;}
+                    )*
+                    *main_pos = furthest;
+                }
+            }
+        }
+    }
+
+    // It's possible to make a macro that use shorter input but i'm tryna make it simple here
+    //
+    // Built by using Helix macro:
+    //
+    // xyp<S-F>=;b;vf<S-T>eyp<A-;>i<space>jk;f=;b_<C-a>f<S-T>ev<A-;>l<C-a>
+    //
+    // starting from
+    //
+    // impl_TupleFnOnce! { 0 => T0 }
+
+    impl_sequence! { 0 T0 }
+    impl_sequence! { 0 T0 1 T1 }
+    impl_sequence! { 0 T0 1 T1 2 T2 }
+    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 }
+    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 }
+    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 }
+    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 }
+    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 }
+    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 }
+    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 }
+    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 }
+    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 }
+    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 }
+    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 }
+    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 }
+    impl_sequence! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 15 T15 }
+
+    impl_parallel! { 0 T0 }
+    impl_parallel! { 0 T0 1 T1 }
+    impl_parallel! { 0 T0 1 T1 2 T2 }
+    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 }
+    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 }
+    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 }
+    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 }
+    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 }
+    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 }
+    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 }
+    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 }
+    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 }
+    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 }
+    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 }
+    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 }
+    impl_parallel! { 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 15 T15 }
+}

--- a/src/combinator/state.rs
+++ b/src/combinator/state.rs
@@ -1,0 +1,173 @@
+use tween::ComponentTween;
+
+use crate::interpolate::*;
+use crate::tween::{self, TargetComponent, Tween};
+use bevy::prelude::*;
+
+/// Generic target and state
+pub struct TargetState<T, V> {
+    /// The target type
+    pub target: T,
+    /// The target's value or property
+    pub value: V,
+}
+
+impl<T, V> TargetState<T, V> {
+    /// Create new [`TargetState`] from target and initial value
+    /// Recommended to use other methods like:
+    /// - [`TargetComponent::state`]
+    /// - [`TargetAsset::state`](crate::tween::TargetAsset::state)
+    /// - [`TargetResource::state`](crate::tween::TargetAsset::state)
+    pub fn new(target: T, value: V) -> Self {
+        TargetState { target, value }
+    }
+
+    /// Change the value
+    pub fn set_value(&mut self, new_value: V) -> &mut Self {
+        self.value = new_value;
+        self
+    }
+
+    /// Change the target
+    pub fn set_target(&mut self, new_target: T) -> &mut Self {
+        self.target = new_target;
+        self
+    }
+}
+
+impl<T, V> TargetState<T, V>
+where
+    T: Clone,
+{
+    /// Create [`ComponentTween`] of a value from this state and relative interpolator constructor
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy::prelude::*;
+    /// # use bevy_tween::prelude::*;
+    /// use bevy_tween::interpolate::translation_to;
+    ///
+    /// # let sprite = Entity::PLACEHOLDER;
+    /// let my_target = sprite.into_target();
+    /// let mut my_target_translation = my_target.state(Vec3::ZERO);
+    ///
+    /// // Creating a ComponentTween that's tweening from previous value to Vec3::ONE
+    /// let tween = my_target_translation.with(translation_to(Vec3::ONE));
+    /// ```
+    pub fn with<I>(&mut self, f: impl FnOnce(&mut V) -> I) -> Tween<T, I> {
+        let interpolator = f(&mut self.value);
+        Tween {
+            target: self.target.clone(),
+            interpolator,
+        }
+    }
+}
+
+/// Extension trait to create [`TransformTargetState`]
+pub trait TransformTargetStateExt {
+    /// Create [`TransformTargetState`] from [`Self`] and initial value
+    fn transform_state(&self, value: Transform) -> TransformTargetState;
+}
+
+impl TransformTargetStateExt for TargetComponent {
+    /// Create [`TransformTargetState`] from [`TargetComponent`] and initial value
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_tween::prelude::*;
+    /// # use bevy::prelude::*;
+    /// # let sprite = Entity::PLACEHOLDER;
+    /// let my_target = sprite.into_target();
+    /// let mut my_target_translation = my_target.transform_state(Transform::IDENTITY);
+    ///
+    /// // Creating a ComponentTween that's tweening from previous translation to Vec3::ONE
+    /// let tween = my_target_translation.translation_to(Vec3::ONE);
+    /// ```
+    fn transform_state(&self, value: Transform) -> TransformTargetState {
+        TransformTargetState::new(self.clone(), value)
+    }
+}
+
+/// Transform state for animating entity
+pub struct TransformTargetState {
+    target: TargetComponent,
+    value: Transform,
+}
+
+impl TransformTargetState {
+    /// Create new [`TransformTargetState`]
+    pub fn new(
+        target: TargetComponent,
+        value: Transform,
+    ) -> TransformTargetState {
+        TransformTargetState { target, value }
+    }
+
+    /// Create [`ComponentTween`] of transform from this state and relative interpolator constructor
+    pub fn transform_with<I>(
+        &mut self,
+        f: impl FnOnce(&mut Transform) -> I,
+    ) -> Tween<TargetComponent, I> {
+        let interpolator = f(&mut self.value);
+        Tween {
+            target: self.target.clone(),
+            interpolator,
+        }
+    }
+
+    /// Create [`ComponentTween`] of transform's translation from this state and relative interpolator constructor
+    pub fn translation_with<I>(
+        &mut self,
+        f: impl FnOnce(&mut Vec3) -> I,
+    ) -> Tween<TargetComponent, I> {
+        self.transform_with(|v| f(&mut v.translation))
+    }
+
+    /// Create [`ComponentTween`] of transform's rotation from this state and relative interpolator constructor
+    pub fn rotation_with<I>(
+        &mut self,
+        f: impl FnOnce(&mut Quat) -> I,
+    ) -> Tween<TargetComponent, I> {
+        self.transform_with(|v| f(&mut v.rotation))
+    }
+
+    /// Create [`ComponentTween`] of transform's scale from this state and relative interpolator constructor
+    pub fn scale_with<I>(
+        &mut self,
+        f: impl FnOnce(&mut Vec3) -> I,
+    ) -> Tween<TargetComponent, I> {
+        self.transform_with(|v| f(&mut v.scale))
+    }
+
+    /// Create [`ComponentTween`] of transform's translation tweening to provided input
+    pub fn translation_to(&mut self, to: Vec3) -> ComponentTween<Translation> {
+        self.translation_with(translation_to(to))
+    }
+
+    /// Create [`ComponentTween`] of transform's rotation tweening to provided input
+    pub fn rotation_to(&mut self, to: Quat) -> ComponentTween<Rotation> {
+        self.rotation_with(rotation_to(to))
+    }
+
+    /// Create [`ComponentTween`] of transform's scale tweening to provided input
+    pub fn scale_to(&mut self, to: Vec3) -> ComponentTween<Scale> {
+        self.scale_with(scale_to(to))
+    }
+
+    /// Create [`ComponentTween`] of transform's translation tweening by provided input
+    pub fn translation_by(&mut self, by: Vec3) -> ComponentTween<Translation> {
+        self.translation_with(translation_by(by))
+    }
+
+    /// Create [`ComponentTween`] of transform's rotation tweening by provided input
+    pub fn rotation_by(&mut self, by: Quat) -> ComponentTween<Rotation> {
+        self.rotation_with(rotation_by(by))
+    }
+
+    /// Create [`ComponentTween`] of transform's scale tweening by provided input
+    pub fn scale_by(&mut self, by: Vec3) -> ComponentTween<Scale> {
+        self.scale_with(scale_by(by))
+    }
+}


### PR DESCRIPTION
- Move `combinator/state` module into a file.
- Move all animation combinators into `combinator/animation_combinators` module.
- Add private `time_runner_or_default` method to reduce boilerplate.
- Add more (forgotton) methods to `AnimationBuilder`
  - `skipped`
  - `disabled` which combines `skipped` and `paused`
  - `time_scale`
  - `direction`
- Update CHANGELOG.md and also include changes from previous non PR commits.
- Update docs for some combinators