### PR TITLE
Trigger events with observer

### DIFF
--- a/src/combinator/animation_combinators.rs
+++ b/src/combinator/animation_combinators.rs
@@ -85,8 +85,7 @@ where
 ///
 /// <div class="warning">
 ///
-/// Your event should be registered with [`TweenEventPlugin`](crate::tween_event::TweenEventPlugin)
-/// or [`TweenEventTakingPlugin`](crate::tween_event::TweenEventTakingPlugin).
+/// Your event should be registered with [`TweenEventPlugin`](crate::tween_event::TweenEventPlugin).
 ///
 /// </div>
 pub fn event<Data>(
@@ -111,8 +110,7 @@ where
 ///
 /// <div class="warning">
 ///
-/// Your event should be registered with [`TweenEventPlugin`](crate::tween_event::TweenEventPlugin)
-/// or [`TweenEventTakingPlugin`](crate::tween_event::TweenEventTakingPlugin).
+/// Your event should be registered with [`TweenEventPlugin`](crate::tween_event::TweenEventPlugin).
 ///
 /// </div>
 pub fn event_at<Data>(
@@ -138,8 +136,7 @@ where
 ///
 /// <div class="warning">
 ///
-/// Your event should be registered with [`TweenEventPlugin`](crate::tween_event::TweenEventPlugin)
-/// or [`TweenEventTakingPlugin`](crate::tween_event::TweenEventTakingPlugin).
+/// Your event should be registered with [`TweenEventPlugin`](crate::tween_event::TweenEventPlugin).
 ///
 /// </div>
 pub fn event_for<Data>(
@@ -168,8 +165,7 @@ where
 ///
 /// <div class="warning">
 ///
-/// Your event should be registered with [`TweenEventPlugin`](crate::tween_event::TweenEventPlugin)
-/// or [`TweenEventTakingPlugin`](crate::tween_event::TweenEventTakingPlugin).
+/// Your event should be registered with [`TweenEventPlugin`](crate::tween_event::TweenEventPlugin).
 ///
 /// </div>
 pub fn event_exact<S, Data>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,6 @@ pub use tween::resource_dyn_tween_system;
 pub use tween::resource_tween_system;
 
 pub use tween_event::tween_event_system;
-pub use tween_event::tween_event_taking_system;
 
 /// Default plugins for using crate.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,7 +524,6 @@ pub enum TweenSystemSet {
     ///
     /// Events is not necessary related to tweening but their code is still working in the same area.
     /// - [`tween::tween_event_system`]
-    /// - [`tween::tween_event_taking_system`]
     ApplyTween,
 }
 

--- a/src/tween.rs
+++ b/src/tween.rs
@@ -783,6 +783,7 @@ pub type DefaultTweenEventsPlugin =
 #[allow(deprecated)]
 #[allow(clippy::type_complexity)]
 pub fn tween_event_system<Data>(
+    commands: Commands,
     q_tween_event_data: Query<
         (
             Entity,
@@ -796,7 +797,11 @@ pub fn tween_event_system<Data>(
 ) where
     Data: Clone + Send + Sync + 'static,
 {
-    crate::tween_event::tween_event_system(q_tween_event_data, event_writer)
+    crate::tween_event::tween_event_system(
+        commands,
+        q_tween_event_data,
+        event_writer,
+    )
 }
 
 #[deprecated(
@@ -808,6 +813,7 @@ pub fn tween_event_system<Data>(
 #[allow(deprecated)]
 #[allow(clippy::type_complexity)]
 pub fn tween_event_taking_system<Data>(
+    commands: Commands,
     q_tween_event_data: Query<
         (
             Entity,
@@ -819,9 +825,10 @@ pub fn tween_event_taking_system<Data>(
     >,
     event_writer: EventWriter<TweenEvent<Data>>,
 ) where
-    Data: Send + Sync + 'static,
+    Data: Clone + Send + Sync + 'static,
 {
     crate::tween_event::tween_event_taking_system(
+        commands,
         q_tween_event_data,
         event_writer,
     )

--- a/src/tween.rs
+++ b/src/tween.rs
@@ -803,33 +803,3 @@ pub fn tween_event_system<Data>(
         event_writer,
     )
 }
-
-#[deprecated(
-    since = "0.6.0",
-    note = "use `bevy_tween::tween_event::tween_event_taking_system` instead or `TweenEventTakingPlugin` if you're registering custom tween event"
-)]
-#[allow(missing_docs)]
-#[doc(hidden)]
-#[allow(deprecated)]
-#[allow(clippy::type_complexity)]
-pub fn tween_event_taking_system<Data>(
-    commands: Commands,
-    q_tween_event_data: Query<
-        (
-            Entity,
-            &mut TweenEventData<Data>,
-            &bevy_time_runner::TimeSpanProgress,
-            Option<&TweenInterpolationValue>,
-        ),
-        Without<SkipTween>,
-    >,
-    event_writer: EventWriter<TweenEvent<Data>>,
-) where
-    Data: Clone + Send + Sync + 'static,
-{
-    crate::tween_event::tween_event_taking_system(
-        commands,
-        q_tween_event_data,
-        event_writer,
-    )
-}

--- a/src/tween_event.rs
+++ b/src/tween_event.rs
@@ -112,7 +112,7 @@ impl PluginGroup for DefaultTweenEventPlugins {
 /// Fires [`TweenEvent`] whenever [`TimeSpanProgress`] and [`TweenEventData`] exist in the same entity.
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash, Component, Reflect)]
 #[reflect(Component)]
-pub struct TweenEventData<Data = ()>(Data)
+pub struct TweenEventData<Data = ()>(pub Data)
 where
     Data: Send + Sync + 'static;
 

--- a/src/tween_event.rs
+++ b/src/tween_event.rs
@@ -5,14 +5,12 @@
 //! **Plugins**:
 //! - [`DefaultTweenEventPlugins`]
 //! - [`TweenEventPlugin<Data>`]
-//! - [`TweenEventTakingPlugin<Data>`]
 //!
 //! **Components**:
 //! - [`TweenEventData`]
 //!
 //! **Systems**
 //! - [`tween_event_system`]
-//! - [`tween_event_taking_system`]
 //!
 //! **Events**:
 //! - [`TweenEvent<Data>`]
@@ -23,7 +21,6 @@
 //!
 //! Add this plugin for your custom data.
 //! - [`TweenEventPlugin<Data>`]
-//! - [`TweenEventTakingPlugin<Data>`]
 //!
 //! See [`DefaultTweenEventPlugins`] for default events which is also added in
 //! [`DefaultTweenPlugins`](crate::DefaultTweenPlugins)
@@ -38,8 +35,7 @@ use bevy_time_runner::TimeSpanProgress;
 
 use crate::tween::{SkipTween, TweenInterpolationValue};
 
-/// Plugin for simple generic event that fires at a specific time span
-/// See [`TweenEventTakingPlugin`] if your custom data is not [`Clone`].
+/// Plugin for simple generic event that fires at a specific time span.
 #[derive(Default)]
 pub struct TweenEventPlugin<Data>
 where
@@ -131,7 +127,7 @@ impl TweenEventData<()> {
 }
 
 /// Fires whenever [`TimeSpanProgress`] and [`TweenEventData`] exist in the same entity
-/// by [`tween_event_system`] or [`tween_event_taking_system`].
+/// by [`tween_event_system`].
 #[derive(Debug, Clone, PartialEq, Event, Reflect)]
 pub struct TweenEvent<Data = ()> {
     /// Custom user data


### PR DESCRIPTION
Adds observer triggers on top of normal events so that users can now use observers to listen to tween events (this is similar to the approach used [upstream](https://github.com/bevyengine/bevy/blob/bb81a2cdb3108a2265802ce0f1ebcca1c7c0858c/crates/bevy_picking/src/events.rs#L436-L437)). 

This adds a new `Clone` constraint to `tween_event_taking_system`, because the event now needs to be moved to both the observer and the event writer.