### PR TITLE
Add Delta Tweens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.8.1 - 2025-07-14
+
+### Breaking Changes
+
+- `interpolate` functions now take an additional `previous_value` argument, which you can now use to make delta tweens.
+Still, you'd have to update everything that implements `Interpolator` to match the new signature.
+
+### Changes
+
+- Migrate to Bevy 0.16.1
+- You can now use `previous_value` to make tweens that apply delta instead of set values
+  (see `TranslationDelta` for example). This is useful when you want two ongoing tweens to affect the same entity.
+
 ## v0.8.0 - 2025-05-09
 
 ### Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.bevy]
-version = "0.16.0"
+version = "0.16.1"
 default-features = false
 features = ["std"]
 
@@ -28,7 +28,7 @@ default-features = false
 features = ["curve"]
 
 [dependencies.bevy_time_runner]
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies.serde]
 version = "1"
@@ -45,7 +45,7 @@ optional = true
 
 [dev-dependencies]
 bevy-inspector-egui = "0.31.0"
-rand = "0.9.0"
+rand = "0.9.1"
 
 [dev-dependencies.bevy]
 version = "0.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,3 +165,6 @@ required-features = [
     "bevy_lookup_curve",
 ]
 
+[[example]]
+name = "delta_tweens"
+path = "examples/demo/delta_tweens.rs"

--- a/examples/animation/banner_bounce.rs
+++ b/examples/animation/banner_bounce.rs
@@ -362,7 +362,7 @@ fn animation(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 type InterpolateSpriteAlpha = Box<dyn Interpolator<Item = Sprite>>;
 fn sprite_alpha(start: f32, end: f32) -> InterpolateSpriteAlpha {
-    Box::new(interpolate::closure(move |sprite: &mut Sprite, value| {
+    Box::new(interpolate::closure(move |sprite: &mut Sprite, value, _| {
         sprite.color = sprite.color.with_alpha(start.lerp(end, value));
     }))
 }

--- a/examples/demo/delta_tweens.rs
+++ b/examples/demo/delta_tweens.rs
@@ -1,0 +1,65 @@
+use std::time::Duration;
+use bevy::{
+    prelude::*,
+};
+use bevy_tween::{
+    combinator::*, prelude::*,
+    tween::AnimationTarget,
+};
+
+fn secs(secs: f32) -> Duration {
+    Duration::from_secs_f32(secs)
+}
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, DefaultTweenPlugins))
+        .add_systems(Startup, (
+            setup,
+            spawn_circle_with_tweens
+        ))
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2d);
+}
+
+fn spawn_circle_with_tweens(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+) {
+    let circle_filled_image = asset_server.load("circle_filled.png");
+    let circle_transform = Transform::from_xyz(400., -200., 0.);
+    let vertical_delta = Vec3::new(0.0, 400.0, 0.0);
+    let horizontal_delta = Vec3::new(-800.0, 0.0, 0.0);
+    let float_duration = secs(4.0);
+    let circle = AnimationTarget.into_target();
+    let mut circle_transform_state = circle.transform_state(circle_transform);
+
+    let mut circle_commands = commands
+        .spawn((
+            Sprite {
+                image: circle_filled_image,
+                ..default()
+            },
+            circle_transform,
+            AnimationTarget,
+        ));
+
+    circle_commands.animation()
+        .repeat(Repeat::Infinitely)
+        .repeat_style(RepeatStyle::PingPong)
+        .insert(parallel((
+            tween(
+                float_duration,
+                EaseKind::BounceIn,
+                circle_transform_state.translation_delta_by(horizontal_delta),
+            ),
+            tween(
+                float_duration,
+                EaseKind::SineInOut,
+                circle_transform_state.translation_delta_by(vertical_delta),
+            )
+        )));
+}

--- a/examples/demo/follow.rs
+++ b/examples/demo/follow.rs
@@ -96,7 +96,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 .insert_tween_here(
                     Duration::from_secs(2),
                     EaseKind::CubicInOut,
-                    jeb.with_closure(|transform: &mut Transform, value| {
+                    jeb.with_closure(|transform: &mut Transform, value, _| {
                         let start = 0.;
                         let end = TAU;
                         transform.rotation =

--- a/examples/demo/hold.rs
+++ b/examples/demo/hold.rs
@@ -27,7 +27,7 @@ mod interpolate {
     impl Interpolator for EffectIntensity {
         type Item = super::EffectIntensitiy;
 
-        fn interpolate(&self, item: &mut Self::Item, value: f32) {
+        fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
             item.0 = self.start.lerp(self.end, value)
         }
     }

--- a/examples/demo/sprite_sheet.rs
+++ b/examples/demo/sprite_sheet.rs
@@ -25,7 +25,7 @@ mod interpolate {
     impl Interpolator for AtlasIndex {
         type Item = Sprite;
 
-        fn interpolate(&self, item: &mut Self::Item, value: f32) {
+        fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
             let Some(texture_atlas) = &mut item.texture_atlas else {
                 return;
             };

--- a/examples/interpolator.rs
+++ b/examples/interpolator.rs
@@ -34,7 +34,7 @@ mod interpolate {
     impl Interpolator for CircleRadius {
         type Item = Circle;
 
-        fn interpolate(&self, item: &mut Self::Item, value: f32) {
+        fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
             item.radius = self.start.lerp(self.end, value);
         }
     }
@@ -51,7 +51,7 @@ mod interpolate {
     impl Interpolator for CircleHue {
         type Item = Circle;
 
-        fn interpolate(&self, item: &mut Self::Item, value: f32) {
+        fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
             item.hue = self.start.lerp(self.end, value);
         }
     }

--- a/examples/interpolator.rs
+++ b/examples/interpolator.rs
@@ -99,7 +99,7 @@ fn setup(mut commands: Commands) {
             Duration::from_secs(2),
             EaseKind::Linear,
             // Requires [`component_dyn_tween_system`]
-            circle.with_closure(|circle: &mut Circle, value| {
+            circle.with_closure(|circle: &mut Circle, value, _| {
                 circle.spikiness = (2.).lerp(4., value);
             }),
         ),

--- a/src/combinator/state.rs
+++ b/src/combinator/state.rs
@@ -170,4 +170,19 @@ impl TransformTargetState {
     pub fn scale_by(&mut self, by: Vec3) -> ComponentTween<Scale> {
         self.scale_with(scale_by(by))
     }
+
+    /// Create delta [`ComponentTween`] of transform's translation tweening by provided input
+    pub fn translation_delta_by(&mut self, by: Vec3) -> ComponentTween<TranslationDelta> {
+        self.translation_with(translation_delta_by(by))
+    }
+
+    /// Create delta [`ComponentTween`] of transform's rotation tweening by provided input
+    pub fn rotation_delta_by(&mut self, by: Quat) -> ComponentTween<RotationDelta> {
+        self.rotation_with(rotation_delta_by(by))
+    }
+    
+    /// Create delta [`ComponentTween`] of scale's rotation tweening by provided input
+    pub fn scale_delta_by(&mut self, by: Vec3) -> ComponentTween<ScaleDelta> {
+        self.scale_with(scale_delta_by(by))
+    }
 }

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -45,7 +45,7 @@
 //!     type Item = Foo;
 //!
 //!     // Then we define how we want to interpolate `Foo`
-//!     fn interpolate(&self, item: &mut Self::Item, value: f32) {
+//!     fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
 //!         // Usually if the type already have the `.lerp` function provided
 //!         // by the `FloatExt` trait then we can use just that
 //!         item.0 = self.start.lerp(self.end, value);
@@ -90,13 +90,13 @@ use bevy::prelude::*;
 /// Alias for an `Interpolator` as a boxed trait object.
 pub type BoxedInterpolator<Item> = Box<dyn Interpolator<Item = Item>>;
 
-type InterpolatorClosure<I> = Box<dyn Fn(&mut I, f32) + Send + Sync + 'static>;
+type InterpolatorClosure<I> = Box<dyn Fn(&mut I, f32, f32) + Send + Sync + 'static>;
 
 /// Create boxed closure in order to be used with dynamic [`Interpolator`]
 pub fn closure<I, F>(f: F) -> InterpolatorClosure<I>
 where
     I: 'static,
-    F: Fn(&mut I, f32) + Send + Sync + 'static,
+    F: Fn(&mut I, f32, f32) + Send + Sync + 'static,
 {
     Box::new(f)
 }
@@ -115,7 +115,7 @@ pub trait Interpolator: Send + Sync + 'static {
     /// The value should be already sampled from an [`Interpolation`]
     ///
     /// [`Interpolation`]: crate::interpolation::Interpolation
-    fn interpolate(&self, item: &mut Self::Item, value: f32);
+    fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32);
 }
 
 // /// Reflect [`Interpolator`] trait

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -197,7 +197,7 @@ pub trait Interpolator: Send + Sync + 'static {
 
 /// Default interpolators
 ///
-/// Register type and systems for the following interpolators:
+/// Register type and systems for the following interpolators and their delta interpolators:
 /// - [`Translation`]
 /// - [`Rotation`]
 /// - [`Scale`]
@@ -217,29 +217,47 @@ impl Plugin for DefaultInterpolatorsPlugin {
             tween::component_tween_system::<Rotation>(),
             tween::component_tween_system::<Scale>(),
             tween::component_tween_system::<AngleZ>(),
+            tween::component_tween_system::<TranslationDelta>(),
+            tween::component_tween_system::<RotationDelta>(),
+            tween::component_tween_system::<ScaleDelta>(),
+            tween::component_tween_system::<AngleZDelta>()
         ))
         .register_type::<tween::ComponentTween<Translation>>()
         .register_type::<tween::ComponentTween<Rotation>>()
         .register_type::<tween::ComponentTween<Scale>>()
-        .register_type::<tween::ComponentTween<AngleZ>>();
+        .register_type::<tween::ComponentTween<AngleZ>>()
+        .register_type::<tween::ComponentTween<TranslationDelta>>()
+        .register_type::<tween::ComponentTween<RotationDelta>>()
+        .register_type::<tween::ComponentTween<ScaleDelta>>()
+        .register_type::<tween::ComponentTween<AngleZDelta>>();
 
         #[cfg(feature = "bevy_sprite")]
-        app.add_tween_systems(tween::component_tween_system::<SpriteColor>())
-            .register_type::<tween::ComponentTween<SpriteColor>>();
+        app.add_tween_systems((
+            tween::component_tween_system::<SpriteColor>(),
+            tween::component_tween_system::<SpriteColorDelta>(),
+        ))
+            .register_type::<tween::ComponentTween<SpriteColor>>()
+            .register_type::<tween::ComponentTween<SpriteColorDelta>>();
 
         #[cfg(feature = "bevy_ui")]
         app.add_tween_systems((
             tween::component_tween_system::<ui::BackgroundColor>(),
             tween::component_tween_system::<ui::BorderColor>(),
+            tween::component_tween_system::<BackgroundColorDelta>(),
+            tween::component_tween_system::<BorderColorDelta>(),
         ))
-        .register_type::<tween::ComponentTween<ui::BackgroundColor>>()
-        .register_type::<tween::ComponentTween<ui::BorderColor>>();
+            .register_type::<tween::ComponentTween<ui::BackgroundColor>>()
+            .register_type::<tween::ComponentTween<ui::BorderColor>>()
+            .register_type::<tween::ComponentTween<BackgroundColorDelta>>()
+            .register_type::<tween::ComponentTween<BorderColorDelta>>();
 
         #[cfg(all(feature = "bevy_sprite", feature = "bevy_asset",))]
-        app.add_tween_systems(
+        app.add_tween_systems((
             tween::asset_tween_system::<sprite::ColorMaterial>(),
-        )
-        .register_type::<tween::AssetTween<sprite::ColorMaterial>>();
+            tween::asset_tween_system::<ColorMaterialDelta>(),
+        ))
+            .register_type::<tween::AssetTween<sprite::ColorMaterial>>()
+            .register_type::<tween::ComponentTween<ColorMaterialDelta>>();
     }
 }
 

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -11,6 +11,7 @@
 //! - [`AngleZ`]
 //! - [`SpriteColor`]
 //! - [`ColorMaterial`]
+//! - All their delta variants (such as [`TranslationDelta`])
 //!
 //! # Your own [`Interpolator`]
 //!

--- a/src/interpolate/blanket_impl.rs
+++ b/src/interpolate/blanket_impl.rs
@@ -7,8 +7,8 @@ where
 {
     type Item = I::Item;
 
-    fn interpolate(&self, item: &mut Self::Item, value: f32) {
-        (**self).interpolate(item, value)
+    fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
+        (**self).interpolate(item, value, previous_value)
     }
 }
 
@@ -18,8 +18,8 @@ where
 {
     type Item = I::Item;
 
-    fn interpolate(&self, item: &mut Self::Item, value: f32) {
-        (**self).interpolate(item, value)
+    fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
+        (**self).interpolate(item, value, previous_value)
     }
 }
 
@@ -29,15 +29,15 @@ where
 {
     type Item = I::Item;
 
-    fn interpolate(&self, item: &mut Self::Item, value: f32) {
-        (**self).interpolate(item, value)
+    fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
+        (**self).interpolate(item, value, previous_value)
     }
 }
 
-impl<I: 'static> Interpolator for dyn Fn(&mut I, f32) + Send + Sync + 'static {
+impl<I: 'static> Interpolator for dyn Fn(&mut I, f32, f32) + Send + Sync + 'static {
     type Item = I;
 
-    fn interpolate(&self, item: &mut Self::Item, value: f32) {
-        self(item, value)
+    fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
+        self(item, value, previous_value)
     }
 }

--- a/src/interpolate/sprite.rs
+++ b/src/interpolate/sprite.rs
@@ -62,7 +62,7 @@ pub fn sprite_color_to(to: Color) -> impl Fn(&mut Color) -> SpriteColor {
 // type ReflectInterpolatorColorMaterial =
 //     ReflectInterpolator<bevy::sprite::ColorMaterial>;
 
-/// [`Interpolator`] for [`Sprite`]'s [`ColorMaterial`]
+/// [`Interpolator`] for [`Sprite`]'s ColorMaterial
 #[derive(Debug, Default, Clone, PartialEq, Reflect)]
 // #[reflect(InterpolatorColorMaterial)]
 pub struct ColorMaterial {
@@ -80,7 +80,7 @@ impl Interpolator for ColorMaterial {
     }
 }
 
-/// delta [`Interpolator`] for [`Sprite`]'s [`ColorMaterial`]
+/// delta [`Interpolator`] for [`Sprite`]'s ColorMaterial
 #[derive(Debug, Default, Clone, PartialEq, Reflect)]
 pub struct ColorMaterialDelta {
     #[allow(missing_docs)]

--- a/src/interpolate/sprite.rs
+++ b/src/interpolate/sprite.rs
@@ -35,8 +35,11 @@ impl Interpolator for SpriteColorDelta {
     type Item = Sprite;
 
     fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
-        let value_delta = value - previous_value;
-        item.color.mix_assign(self.end, value_delta);
+        let previous_color_as_vec = self.start.mix(&self.end, previous_value).to_linear().to_vec4();
+        let next_color_as_vec = self.start.mix(&self.end, value).to_linear().to_vec4();
+        let color_delta = next_color_as_vec - previous_color_as_vec;
+        let updated_color = item.color.to_linear().to_vec4() + color_delta;
+        item.color = Color::srgba(updated_color.x, updated_color.y, updated_color.z, updated_color.w);
     }
 }
 
@@ -90,8 +93,11 @@ impl Interpolator for ColorMaterialDelta {
     type Item = bevy::sprite::ColorMaterial;
 
     fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
-        let value_delta = value - previous_value;
-        item.color.mix_assign(self.end, value_delta);
+        let previous_color_as_vec = self.start.mix(&self.end, previous_value).to_linear().to_vec4();
+        let next_color_as_vec = self.start.mix(&self.end, value).to_linear().to_vec4();
+        let color_delta = next_color_as_vec - previous_color_as_vec;
+        let updated_color = item.color.to_linear().to_vec4() + color_delta;
+        item.color = Color::srgba(updated_color.x, updated_color.y, updated_color.z, updated_color.w);
     }
 }
 

--- a/src/interpolate/sprite.rs
+++ b/src/interpolate/sprite.rs
@@ -16,7 +16,7 @@ pub struct SpriteColor {
 impl Interpolator for SpriteColor {
     type Item = Sprite;
 
-    fn interpolate(&self, item: &mut Self::Item, value: f32) {
+    fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
         item.color = self.start.mix(&self.end, value)
     }
 }
@@ -52,7 +52,7 @@ pub struct ColorMaterial {
 impl Interpolator for ColorMaterial {
     type Item = bevy::sprite::ColorMaterial;
 
-    fn interpolate(&self, item: &mut Self::Item, value: f32) {
+    fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
         item.color = self.start.mix(&self.end, value);
     }
 }

--- a/src/interpolate/sprite.rs
+++ b/src/interpolate/sprite.rs
@@ -21,6 +21,26 @@ impl Interpolator for SpriteColor {
     }
 }
 
+
+/// delta [`Interpolator`] for [`Sprite`]'s color
+#[derive(Debug, Default, Clone, PartialEq, Reflect)]
+pub struct SpriteColorDelta {
+    #[allow(missing_docs)]
+    pub start: Color,
+    #[allow(missing_docs)]
+    pub end: Color,
+}
+
+impl Interpolator for SpriteColorDelta {
+    type Item = Sprite;
+
+    fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
+        let value_delta = value - previous_value;
+        item.color.mix_assign(self.end, value_delta);
+    }
+}
+
+
 /// Constructor for [`SpriteColor`]
 pub fn sprite_color(start: Color, end: Color) -> SpriteColor {
     SpriteColor { start, end }
@@ -56,6 +76,25 @@ impl Interpolator for ColorMaterial {
         item.color = self.start.mix(&self.end, value);
     }
 }
+
+/// delta [`Interpolator`] for [`Sprite`]'s [`ColorMaterial`]
+#[derive(Debug, Default, Clone, PartialEq, Reflect)]
+pub struct ColorMaterialDelta {
+    #[allow(missing_docs)]
+    pub start: Color,
+    #[allow(missing_docs)]
+    pub end: Color,
+}
+
+impl Interpolator for ColorMaterialDelta {
+    type Item = bevy::sprite::ColorMaterial;
+
+    fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
+        let value_delta = value - previous_value;
+        item.color.mix_assign(self.end, value_delta);
+    }
+}
+
 
 /// Constructor for [`ColorMaterial`](crate::interpolate::ColorMaterial)
 pub fn color_material(start: Color, end: Color) -> ColorMaterial {

--- a/src/interpolate/transform.rs
+++ b/src/interpolate/transform.rs
@@ -20,6 +20,25 @@ impl Interpolator for Translation {
     }
 }
 
+/// delta [`Interpolator`] for [`Transform`]'s translation.
+#[derive(Debug, Default, Clone, PartialEq, Reflect)]
+pub struct TranslationDelta {
+    #[allow(missing_docs)]
+    pub start: Vec3,
+    #[allow(missing_docs)]
+    pub end: Vec3,
+}
+impl Interpolator for TranslationDelta {
+    type Item = Transform;
+
+    fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
+        let previous_translation = self.start.lerp(self.end, previous_value);
+        let next_translation = self.start.lerp(self.end, value);
+        let translation_delta = next_translation - previous_translation;
+        item.translation += translation_delta;
+    }
+}
+
 /// Constructor for [`Translation`]
 pub fn translation(start: Vec3, end: Vec3) -> Translation {
     Translation { start, end }
@@ -45,6 +64,16 @@ pub fn translation_by(by: Vec3) -> impl Fn(&mut Vec3) -> Translation {
     }
 }
 
+/// Constructor for [`TranslationDelta`] that's relative to previous value
+/// Since this is a delta tween, it can happen with other ongoing tweens of that type
+pub fn translation_delta_by(by: Vec3) -> impl Fn(&mut Vec3) -> TranslationDelta {
+    move |state| {
+        let start = *state;
+        let end = *state + by;
+        TranslationDelta { start, end }
+    }
+}
+
 /// [`Interpolator`] for [`Transform`]'s rotation using the [`Quat::slerp`] function.
 #[derive(Debug, Default, Clone, PartialEq, Reflect)]
 // #[reflect(InterpolatorTransform)]
@@ -59,6 +88,23 @@ impl Interpolator for Rotation {
 
     fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
         item.rotation = self.start.slerp(self.end, value);
+    }
+}
+
+/// delta [`Interpolator`] for [`Transform`]'s rotation using the [`Quat::slerp`] function.
+#[derive(Debug, Default, Clone, PartialEq, Reflect)]
+pub struct RotationDelta {
+    #[allow(missing_docs)]
+    pub start: Quat,
+    #[allow(missing_docs)]
+    pub end: Quat,
+}
+impl Interpolator for RotationDelta {
+    type Item = Transform;
+
+    fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
+        let value_delta = value - previous_value;
+        item.rotation = item.rotation.slerp(self.end, value_delta);
     }
 }
 
@@ -87,6 +133,18 @@ pub fn rotation_by(by: Quat) -> impl Fn(&mut Quat) -> Rotation {
     }
 }
 
+
+/// Constructor for [`RotationDelta`] that's relative to previous value
+/// Since this is a delta tween, it can happen with other ongoing tweens of that type
+pub fn rotation_delta_by(by: Quat) -> impl Fn(&mut Quat) -> RotationDelta {
+    move |state| {
+        let start = *state;
+        let end = *state + by;
+        *state = state.mul_quat(by);
+        RotationDelta { start, end }
+    }
+}
+
 /// [`Interpolator`] for [`Transform`]'s scale
 #[derive(Debug, Default, Clone, PartialEq, Reflect)]
 // #[reflect(InterpolatorTransform)]
@@ -101,6 +159,24 @@ impl Interpolator for Scale {
 
     fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
         item.scale = self.start.lerp(self.end, value);
+    }
+}
+
+
+/// delta [`Interpolator`] for [`Transform`]'s scale
+#[derive(Debug, Default, Clone, PartialEq, Reflect)]
+pub struct ScaleDelta {
+    #[allow(missing_docs)]
+    pub start: Vec3,
+    #[allow(missing_docs)]
+    pub end: Vec3,
+}
+impl Interpolator for ScaleDelta {
+    type Item = Transform;
+
+    fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
+        let value_delta = value - previous_value;
+        item.scale += item.scale.lerp(self.end, value_delta);
     }
 }
 
@@ -129,6 +205,17 @@ pub fn scale_by(by: Vec3) -> impl Fn(&mut Vec3) -> Scale {
     }
 }
 
+/// Constructor for [`ScaleDelta`] that's relative to previous value
+/// Since this is a delta tween, it can happen with other ongoing tweens of that type
+pub fn scale_delta_by(by: Vec3) -> impl Fn(&mut Vec3) -> ScaleDelta {
+    move |state| {
+        let start = *state;
+        let end = *state + by;
+        *state += by;
+        ScaleDelta { start, end }
+    }
+}
+
 /// [`Interpolator`] for [`Transform`]'s rotation at Z axis.
 /// Usually used for 2D rotation.
 #[derive(Debug, Default, Clone, PartialEq, Reflect)]
@@ -145,6 +232,26 @@ impl Interpolator for AngleZ {
     fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
         let angle = (self.end - self.start).mul_add(value, self.start);
         item.rotation = Quat::from_rotation_z(angle);
+    }
+}
+
+/// [`Interpolator`] for [`Transform`]'s rotation at Z axis.
+/// Usually used for 2D rotation.
+#[derive(Debug, Default, Clone, PartialEq, Reflect)]
+pub struct AngleZDelta {
+    #[allow(missing_docs)]
+    pub start: f32,
+    #[allow(missing_docs)]
+    pub end: f32,
+}
+impl Interpolator for AngleZDelta {
+    type Item = Transform;
+
+    fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
+        let previous_angle = (self.end - self.start).mul_add(previous_value, self.start);
+        let update_angle = (self.end - self.start).mul_add(value, self.start);
+        let angle_delta_as_quat = Quat::from_rotation_z(update_angle - previous_angle);
+        item.rotation = item.rotation.mul_quat(angle_delta_as_quat);
     }
 }
 
@@ -170,5 +277,16 @@ pub fn angle_z_by(by: f32) -> impl Fn(&mut f32) -> AngleZ {
         let end = *state + by;
         *state += by;
         angle_z(start, end)
+    }
+}
+
+/// Constructor for [`AngleZDelta`] that's relative to previous value
+/// Since this is a delta tween, it can happen with other ongoing tweens of that type
+pub fn angle_z_delta_by(by: f32) -> impl Fn(&mut f32) -> AngleZDelta {
+    move |state| {
+        let start = *state;
+        let end = *state + by;
+        *state += by;
+        AngleZDelta {start, end}
     }
 }

--- a/src/interpolate/transform.rs
+++ b/src/interpolate/transform.rs
@@ -103,8 +103,10 @@ impl Interpolator for RotationDelta {
     type Item = Transform;
 
     fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
-        let value_delta = value - previous_value;
-        item.rotation = item.rotation.slerp(self.end, value_delta);
+        let previous_rotation = self.start.slerp(self.end, previous_value);
+        let next_rotation = self.start.slerp(self.end, value);
+        let rotation_delta = next_rotation - previous_rotation;
+        item.rotation = item.rotation.mul_quat(rotation_delta);
     }
 }
 
@@ -175,8 +177,10 @@ impl Interpolator for ScaleDelta {
     type Item = Transform;
 
     fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
-        let value_delta = value - previous_value;
-        item.scale += item.scale.lerp(self.end, value_delta);
+        let previous_scale = self.start.lerp(self.end, previous_value);
+        let next_scale = self.start.lerp(self.end, value);
+        let scale_delta = next_scale - previous_scale;
+        item.scale += scale_delta;
     }
 }
 

--- a/src/interpolate/transform.rs
+++ b/src/interpolate/transform.rs
@@ -15,7 +15,7 @@ pub struct Translation {
 impl Interpolator for Translation {
     type Item = Transform;
 
-    fn interpolate(&self, item: &mut Self::Item, value: f32) {
+    fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
         item.translation = self.start.lerp(self.end, value);
     }
 }
@@ -57,7 +57,7 @@ pub struct Rotation {
 impl Interpolator for Rotation {
     type Item = Transform;
 
-    fn interpolate(&self, item: &mut Self::Item, value: f32) {
+    fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
         item.rotation = self.start.slerp(self.end, value);
     }
 }
@@ -99,7 +99,7 @@ pub struct Scale {
 impl Interpolator for Scale {
     type Item = Transform;
 
-    fn interpolate(&self, item: &mut Self::Item, value: f32) {
+    fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
         item.scale = self.start.lerp(self.end, value);
     }
 }
@@ -142,7 +142,7 @@ pub struct AngleZ {
 impl Interpolator for AngleZ {
     type Item = Transform;
 
-    fn interpolate(&self, item: &mut Self::Item, value: f32) {
+    fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
         let angle = (self.end - self.start).mul_add(value, self.start);
         item.rotation = Quat::from_rotation_z(angle);
     }

--- a/src/interpolate/ui.rs
+++ b/src/interpolate/ui.rs
@@ -31,8 +31,11 @@ impl Interpolator for BackgroundColorDelta {
     type Item = bevy::prelude::BackgroundColor;
 
     fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
-        let value_delta = value - previous_value;
-        item.0.mix_assign(self.end, value_delta);
+        let previous_color_as_vec = self.start.mix(&self.end, previous_value).to_linear().to_vec4();
+        let next_color_as_vec = self.start.mix(&self.end, value).to_linear().to_vec4();
+        let color_delta = next_color_as_vec - previous_color_as_vec;
+        let updated_color = item.0.to_linear().to_vec4() + color_delta;
+        item.0 = Color::srgba(updated_color.x, updated_color.y, updated_color.z, updated_color.w);
     }
 }
 
@@ -84,8 +87,11 @@ impl Interpolator for BorderColorDelta {
     type Item = bevy::prelude::BackgroundColor;
 
     fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
-        let value_delta = value - previous_value;
-        item.0.mix_assign(self.end, value_delta);
+        let previous_color_as_vec = self.start.mix(&self.end, previous_value).to_linear().to_vec4();
+        let next_color_as_vec = self.start.mix(&self.end, value).to_linear().to_vec4();
+        let color_delta = next_color_as_vec - previous_color_as_vec;
+        let updated_color = item.0.to_linear().to_vec4() + color_delta;
+        item.0 = Color::srgba(updated_color.x, updated_color.y, updated_color.z, updated_color.w);
     }
 }
 

--- a/src/interpolate/ui.rs
+++ b/src/interpolate/ui.rs
@@ -13,7 +13,7 @@ pub struct BackgroundColor {
 impl Interpolator for BackgroundColor {
     type Item = bevy::prelude::BackgroundColor;
 
-    fn interpolate(&self, item: &mut Self::Item, value: f32) {
+    fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
         item.0 = self.start.mix(&self.end, value)
     }
 }
@@ -47,7 +47,7 @@ pub struct BorderColor {
 impl Interpolator for BorderColor {
     type Item = bevy::prelude::BorderColor;
 
-    fn interpolate(&self, item: &mut Self::Item, value: f32) {
+    fn interpolate(&self, item: &mut Self::Item, value: f32, _previous_value: f32) {
         item.0 = self.start.mix(&self.end, value)
     }
 }

--- a/src/interpolate/ui.rs
+++ b/src/interpolate/ui.rs
@@ -18,6 +18,24 @@ impl Interpolator for BackgroundColor {
     }
 }
 
+/// delta [`Interpolator`] for Bevy's [`BackgroundColor`](bevy::prelude::BackgroundColor) used in UIs.
+#[derive(Debug, Default, Clone, PartialEq, Reflect)]
+pub struct BackgroundColorDelta {
+    #[allow(missing_docs)]
+    pub start: Color,
+    #[allow(missing_docs)]
+    pub end: Color,
+}
+
+impl Interpolator for BackgroundColorDelta {
+    type Item = bevy::prelude::BackgroundColor;
+
+    fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
+        let value_delta = value - previous_value;
+        item.0.mix_assign(self.end, value_delta);
+    }
+}
+
 /// Constructor for [`BackgroundColor`](crate::interpolate::BackgroundColor)
 pub fn background_color(start: Color, end: Color) -> BackgroundColor {
     BackgroundColor { start, end }
@@ -51,6 +69,26 @@ impl Interpolator for BorderColor {
         item.0 = self.start.mix(&self.end, value)
     }
 }
+
+
+/// delta [`Interpolator`] for Bevy's [`BorderColor`](bevy::prelude::BorderColor) used in UIs.
+#[derive(Debug, Default, Clone, PartialEq, Reflect)]
+pub struct BorderColorDelta {
+    #[allow(missing_docs)]
+    pub start: Color,
+    #[allow(missing_docs)]
+    pub end: Color,
+}
+
+impl Interpolator for BorderColorDelta {
+    type Item = bevy::prelude::BackgroundColor;
+
+    fn interpolate(&self, item: &mut Self::Item, value: f32, previous_value: f32) {
+        let value_delta = value - previous_value;
+        item.0.mix_assign(self.end, value_delta);
+    }
+}
+
 
 /// Constructor for [`BorderColor`](crate::interpolate::BorderColor)
 pub fn border_color(start: Color, end: Color) -> BorderColor {

--- a/src/tween.rs
+++ b/src/tween.rs
@@ -58,7 +58,7 @@
 //!
 //!     impl Interpolator for FooA {
 //!         # type Item = super::Foo;
-//!         # fn interpolate(&self, _item: &mut Self::Item, _value: f32) {
+//!         # fn interpolate(&self, _item: &mut Self::Item, _value: f32, _previous_value: f32) {
 //!         #     todo!()
 //!         # }
 //!         /* ... */
@@ -70,7 +70,7 @@
 //!
 //!     impl Interpolator for FooB {
 //!         # type Item = super::Foo;
-//!         # fn interpolate(&self, _item: &mut Self::Item, _value: f32) {
+//!         # fn interpolate(&self, _item: &mut Self::Item, _value: f32, _previous_value: f32) {
 //!         #     todo!()
 //!         # }
 //!         /* ... */
@@ -82,7 +82,7 @@
 //!
 //!     impl Interpolator for FooC {
 //!         # type Item = super::Foo;
-//!         # fn interpolate(&self, _item: &mut Self::Item, _value: f32) {
+//!         # fn interpolate(&self, _item: &mut Self::Item, _value: f32, _previous_value: f32) {
 //!         #     todo!()
 //!         # }
 //!         /* ... */
@@ -114,21 +114,21 @@
 //! #     pub struct FooA {}
 //! #     impl Interpolator for FooA {
 //! #         type Item = super::Foo;
-//! #         fn interpolate(&self, _item: &mut Self::Item, _value: f32) {
+//! #         fn interpolate(&self, _item: &mut Self::Item, _value: f32, _previous_value: f32) {
 //! #             todo!()
 //! #         }
 //! #     }
 //! #     pub struct FooB {}
 //! #     impl Interpolator for FooB {
 //! #         type Item = super::Foo;
-//! #         fn interpolate(&self, _item: &mut Self::Item, _value: f32) {
+//! #         fn interpolate(&self, _item: &mut Self::Item, _value: f32, _previous_value: f32) {
 //! #             todo!()
 //! #         }
 //! #     }
 //! #     pub struct FooC {}
 //! #     impl Interpolator for FooC {
 //! #         type Item = super::Foo;
-//! #         fn interpolate(&self, _item: &mut Self::Item, _value: f32) {
+//! #         fn interpolate(&self, _item: &mut Self::Item, _value: f32, _previous_value: f32) {
 //! #             todo!()
 //! #         }
 //! #     }
@@ -172,21 +172,21 @@
 //! #     pub struct FooA {}
 //! #     impl Interpolator for FooA {
 //! #         type Item = super::Foo;
-//! #         fn interpolate(&self, _item: &mut Self::Item, _value: f32) {
+//! #         fn interpolate(&self, _item: &mut Self::Item, _value: f32, _previous_value: f32) {
 //! #             todo!()
 //! #         }
 //! #     }
 //! #     pub struct FooB {}
 //! #     impl Interpolator for FooB {
 //! #         type Item = super::Foo;
-//! #         fn interpolate(&self, _item: &mut Self::Item, _value: f32) {
+//! #         fn interpolate(&self, _item: &mut Self::Item, _value: f32, _previous_value: f32) {
 //! #             todo!()
 //! #         }
 //! #     }
 //! #     pub struct FooC {}
 //! #     impl Interpolator for FooC {
 //! #         type Item = super::Foo;
-//! #         fn interpolate(&self, _item: &mut Self::Item, _value: f32) {
+//! #         fn interpolate(&self, _item: &mut Self::Item, _value: f32, _previous_value: f32) {
 //! #             todo!()
 //! #         }
 //! #     }
@@ -251,6 +251,7 @@ pub struct TweenInterpolationValue(pub f32);
 #[derive(
     Debug, Default, Component, Clone, Copy, PartialEq, Eq, Hash, Reflect,
 )]
+#[require(TweenPreviousValue)]
 #[reflect(Component)]
 pub struct Tween<T, I> {
     #[allow(missing_docs)]
@@ -258,6 +259,14 @@ pub struct Tween<T, I> {
     #[allow(missing_docs)]
     pub interpolator: I,
 }
+
+/// Tracks the tween's previous value
+#[derive(
+    Debug, Default, Component, Clone, Copy, Reflect,
+)]
+#[reflect(Component)]
+pub struct TweenPreviousValue(pub f32);
+
 impl<T, I> Tween<T, I>
 where
     I: Interpolator,
@@ -370,7 +379,7 @@ impl TargetComponent {
         closure: F,
     ) -> Tween<Self, Box<dyn Interpolator<Item = C>>>
     where
-        F: Fn(&mut C, f32) + Send + Sync + 'static,
+        F: Fn(&mut C, f32, f32) + Send + Sync + 'static,
         C: Component,
     {
         let closure = crate::interpolate::closure(closure);
@@ -481,7 +490,7 @@ impl TargetResource {
         closure: F,
     ) -> Tween<Self, Box<dyn Interpolator<Item = C>>>
     where
-        F: Fn(&mut C, f32) + Send + Sync + 'static,
+        F: Fn(&mut C, f32, f32) + Send + Sync + 'static,
         C: Component,
     {
         let closure = crate::interpolate::closure(closure);
@@ -549,7 +558,7 @@ impl<A: Asset> TargetAsset<A> {
         closure: F,
     ) -> Tween<Self, Box<dyn Interpolator<Item = C>>>
     where
-        F: Fn(&mut C, f32) + Send + Sync + 'static,
+        F: Fn(&mut C, f32, f32) + Send + Sync + 'static,
         C: Component,
     {
         let closure = crate::interpolate::closure(closure);


### PR DESCRIPTION
You can now have multiple tweens affect the same entity without having to make complex calculations or have to pick one of them!
In practice, added:
* Previous value now provided to each interpolator function (you don't have to use it)
* An example that showcases two tweens affecting the same entity
* A Delta variant to all basic interpolators