### PR TITLE
Add `EventEmittingTween` required components to all `TweenEventData`s

### DIFF
--- a/src/tween_event.rs
+++ b/src/tween_event.rs
@@ -78,9 +78,15 @@ impl PluginGroup for DefaultTweenEventPlugins {
 /// Fires [`TweenEvent`] whenever [`TimeSpanProgress`] and [`TweenEventData`] exist in the same entity.
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash, Component, Reflect)]
 #[reflect(Component)]
+#[require(EventEmittingTween)]
 pub struct TweenEventData<Data = ()>(pub Data)
 where
     Data: Send + Sync + 'static;
+
+/// Used to mark event-emitting tweens (tweens with `TweenEventData<Data>` for some registered `Data`)
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, Component, Reflect)]
+#[reflect(Component)]
+pub struct EventEmittingTween;
 
 impl<Data: Send + Sync + 'static> TweenEventData<Data> {
     /// Create new [`TweenEventData`] with custom user data.


### PR DESCRIPTION
Add `EventEmittingTween` tag for ease of querying all event emitters (instead of having to query each custom user data type event manually)