### PR TITLE
Update to Bevy 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,18 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.bevy]
-version = "0.17.3"
+version = "0.18.0"
 default-features = false
 features = ["std"]
 
 [dependencies.bevy_math]
-version = "0.17.3"
+version = "0.18.0"
 default-features = false
 features = ["curve"]
 
 [dependencies.bevy_time_runner]
-version = "0.5.2"
+git = "https://github.com/natepiano/bevy_time_runner"
+branch = "bevy-0.18"
 
 [dependencies.serde]
 version = "1"
@@ -44,11 +45,11 @@ version = "0.10.0"
 optional = true
 
 [dev-dependencies]
-bevy-inspector-egui = "0.34.0"
+bevy-inspector-egui = "0.36.0"
 rand = "0.9.1"
 
 [dev-dependencies.bevy]
-version = "0.17.3"
+version = "0.18.0"
 default-features = false
 features = [
     "bevy_window",

--- a/src/tween/systems.rs
+++ b/src/tween/systems.rs
@@ -42,8 +42,8 @@ impl From<&QueryEntityError> for QueryEntityErrorWithoutWorld {
             E::QueryDoesNotMatch(entity, archetype_id) => {
                 EH::QueryDoesNotMatch(*entity, *archetype_id)
             }
-            E::EntityDoesNotExist(entity_does_not_exist_error) => {
-                EH::EntityDoesNotExist(entity_does_not_exist_error.entity)
+            E::NotSpawned(entity_not_spawned_error) => {
+                EH::EntityDoesNotExist(entity_not_spawned_error.entity())
             }
             E::AliasedMutability(entity) => EH::AliasedMutability(*entity),
         }


### PR DESCRIPTION
## Summary
- Update bevy and bevy_math from 0.17.3 to 0.18.0
- Update bevy-inspector-egui from 0.34.0 to 0.36.0
- Fix `QueryEntityError::EntityDoesNotExist` renamed to `NotSpawned` in Bevy 0.18

## Dependencies
This PR depends on bevy_time_runner being updated to Bevy 0.18.0 first.
See: https://github.com/Multirious/bevy_time_runner/pull/16

Currently using a git dependency pointing to my fork. Before publishing, please update to the new crates.io version:
```toml
[dependencies.bevy_time_runner]
version = "0.6.0"  # or whatever version you publish
```

## Code Changes
- `src/tween/systems.rs`: Updated `QueryEntityError` match arm for API change