### PR TITLE
Update flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased - XXXX-XX-XX
+- Update flake by [#77](https://github.com/Multirious/bevy_tween/pull/77)
+  - Use latest instead of a version for stableRust in flake.nix
+  - `nix flake update`
+  - Remove flake-utils dependency from flake.nix
+
 ## v0.9.1 - 2025-07-15
 
 - Fix color delta interpolation

--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,12 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742669843,
-        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "lastModified": 1769170682,
+        "narHash": "sha256-oMmN1lVQU0F0W2k6OI3bgdzp2YOHWYUAw79qzDSjenU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "rev": "c5296fdd05cfa2c187990dd909864da9658df755",
         "type": "github"
       },
       "original": {
@@ -36,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
@@ -48,31 +29,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1742870002,
-        "narHash": "sha256-eQnw8ufyLmrboODU8RKVNh2Mv7SACzdoFrRUV5zdNNE=",
+        "lastModified": 1769309768,
+        "narHash": "sha256-AbOIlNO+JoqRJkK1VrnDXhxuX6CrdtIu2hSuy4pxi3g=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b4c18f262dbebecb855136c1ed8047b99a9c75b6",
+        "rev": "140c9dc582cb73ada2d63a2180524fcaa744fad5",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,39 +1,78 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    rust-overlay= {
+    rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    flake-utils = {
-      url = "github:numtide/flake-utils";
-    };
   };
-  outputs = { nixpkgs, flake-utils, ... } @ inputs:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs {
-          overlays = [ (import inputs.rust-overlay) ];
-          inherit system;
-        };
-        buildInputs = with pkgs; [
-          openssl
-          udev alsa-lib-with-plugins vulkan-loader
-          xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXrandr
-          libxkbcommon wayland
-          (rust-bin.stable."1.85.1".default.override {
-            extensions = ["rust-analyzer" "rust-src"];
-          })
-        ];
-        nativeBuildInputs = with pkgs; [
-          pkg-config
-        ];
-        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
-      in
-      {
-        devShells.default = pkgs.mkShell {
-          inherit buildInputs nativeBuildInputs LD_LIBRARY_PATH;
-        };
-      }
-    );
+  outputs =
+    inputs:
+    let
+      forAllSystems =
+        function:
+        inputs.nixpkgs.lib.genAttrs
+          [
+            "x86_64-linux"
+          ]
+          (
+            system:
+            function (
+              import inputs.nixpkgs {
+                inherit system;
+                overlays = [
+                  (import inputs.rust-overlay)
+                ];
+              }
+            )
+          );
+    in
+    {
+      devShells = forAllSystems (
+        pkgs:
+        let
+          buildInputs = with pkgs; [
+            openssl
+            udev
+            alsa-lib-with-plugins
+            vulkan-loader
+            xorg.libX11
+            xorg.libXcursor
+            xorg.libXi
+            xorg.libXrandr
+            libxkbcommon
+            wayland
+          ];
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+          stableRust = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-analyzer"
+              "rust-src"
+            ];
+          };
+          nightlyRust = pkgs.rust-bin.selectLatestNightlyWith (
+            toolchain:
+            toolchain.default.override {
+              extensions = [
+                "rust-analyzer"
+                "rust-src"
+              ];
+            }
+          );
+        in
+        {
+          default = pkgs.mkShell {
+            inherit nativeBuildInputs LD_LIBRARY_PATH;
+            buildInputs = buildInputs ++ [ stableRust ];
+          };
+          docrs = pkgs.mkShell {
+            inherit nativeBuildInputs LD_LIBRARY_PATH;
+            buildInputs = buildInputs ++ [ nightlyRust ];
+          };
+        }
+      );
+    };
 }


### PR DESCRIPTION
- Use latest instead of a version for stableRust in flake.nix 
- `nix flake update`
- Remove flake-utils dependency from flake.nix